### PR TITLE
Fix bower install issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "bower": "^1.7.7",
     "broccoli-asset-rev": "^2.2.0",
     "ember-cli": "1.13.13",
     "ember-cli-app-version": "^1.0.0",


### PR DESCRIPTION
Add bower to devDependencies so we're not relying on the version of the global bower install.

Fixes #36 